### PR TITLE
Removed ESP8266 support

### DIFF
--- a/platformio_sample.ini
+++ b/platformio_sample.ini
@@ -17,25 +17,6 @@ lib_deps =
     bblanchon/ArduinoJson @ ^6.18.5
     tobiasschuerg/ESP8266 Influxdb @ 3.9.0
 
-[env:nodemcuv2_usb]
-platform = espressif8266 @ ^2.6.3
-board = nodemcuv2
-framework = arduino
-monitor_speed = 115200
-monitor_filters = esp8266_exception_decoder
-debug_tool = esp-prog
-debug_init_break = tbreak setup
-
-[env:nodemcuv2_ota]
-platform = espressif8266 @ ^2.6.3
-board = nodemcuv2
-framework = arduino
-monitor_speed = 115200
-upload_protocol = espota
-upload_port = rancilio
-upload_flags =
-    --auth=otapass
-
 [env:esp32_usb]
 platform = espressif32
 board = esp32dev

--- a/src/ISR.h
+++ b/src/ISR.h
@@ -6,24 +6,6 @@
 
 #include <Arduino.h>
 
-#if defined(ESP8266)
-void IRAM_ATTR onTimer1ISR() {
-    timer1_write(6250); // set interrupt time to 20ms
-
-    if (Output <= isrCounter) {
-        digitalWrite(PINHEATER, LOW);
-    } else {
-        digitalWrite(PINHEATER, HIGH);
-    }
-
-    isrCounter += 20; // += 20 because one tick = 20ms
-
-    //set PID output as relais commands
-    if (isrCounter >= windowSize) {
-        isrCounter = 0;
-    }
-}
-#endif
 
 #if defined(ESP32)
 void IRAM_ATTR onTimer(){
@@ -44,21 +26,11 @@ void IRAM_ATTR onTimer(){
 }
 #endif
 
-
 /**
  * @brief Initialize hardware timers
  */
 void initTimer1(void) {
-    #if defined(ESP8266)
-        /* Timer1 ISR - Initialisierung
-         * TIM_DIV1 = 0,   80MHz (80 ticks/us - 104857.588 us max)
-         * TIM_DIV16 = 1,  5MHz (5 ticks/us - 1677721.4 us max)
-         * TIM_DIV256 = 3  312.5Khz (1 tick = 3.2us - 26843542.4 us max)
-         */
-        timer1_isr_init();
-        timer1_attachInterrupt(onTimer1ISR);
-        timer1_write(6250); // DIV256: set interrupt time to 20ms
-    #elif defined(ESP32)
+    #if defined(ESP32)
         timer = timerBegin(0, 80, true); //m
         timerAttachInterrupt(timer, &onTimer, true);//m
         timerAlarmWrite(timer, 10000, true);//m
@@ -68,9 +40,7 @@ void initTimer1(void) {
 }
 
 void enableTimer1(void) {
-    #if defined(ESP8266)
-        timer1_enable(TIM_DIV256, TIM_EDGE, TIM_SINGLE);
-    #elif defined(ESP32)
+    #if defined(ESP32)
         timerAlarmEnable(timer);
     #else
         #error("MCU not supported");
@@ -79,22 +49,17 @@ void enableTimer1(void) {
 
 void disableTimer1(void)
 {
-    #if defined(ESP8266)
-        timer1_disable();
-    #elif defined(ESP32)
+    #if defined(ESP32)
         timerAlarmDisable(timer);
     #else
         #error("MCU not supported");
     #endif
 }
 
-
 bool isTimer1Enabled(void) {
     bool timerEnabled = false;
 
-    #if defined(ESP8266)
-        timerEnabled = ((T1C & (1 << TCTE)) != 0);
-    #elif defined(ESP32)
+    #if defined(ESP32)
         timerEnabled = timerAlarmEnabled(timer);
     #else
         #error("MCU not supported");

--- a/src/RancilioServer.h
+++ b/src/RancilioServer.h
@@ -9,16 +9,10 @@
 
 #include <Arduino.h>
 
-#ifdef ESP32
-    #include <WiFi.h>
-    #include <AsyncTCP.h>
-    #include "FS.h"
-    #include "SPIFFS.h"
-#elif defined(ESP8266)
-    #include <ESP8266WiFi.h>
-    #include <ESPAsyncTCP.h>
-#endif
-
+#include <WiFi.h>
+#include <AsyncTCP.h>
+#include "FS.h"
+#include "SPIFFS.h"
 #include <ESPAsyncWebServer.h>
 #include <ArduinoJson.h>
 

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -208,7 +208,7 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
          case STO_ITEM_PID_KP_STEAM:
             addr = offsetof(sto_data_t, steamkp);
             size = STRUCT_MEMBER_SIZE(sto_data_t, steamkp);
-            break;    
+            break;
 
         default:
             Serial.printf("%s(): invalid item ID %i!\n", __FUNCTION__, itemId);
@@ -281,15 +281,13 @@ static void setDefaults(void) {
  *         <0 - failed
  */
 int storageSetup(void) {
-    #if defined(ESP8266)
-        EEPROM.begin(sizeof(sto_data_t));
-    #elif defined(ESP32)
+    #if defined(ESP32)
         if (!EEPROM.begin(sizeof(sto_data_t))) {
             Serial.printf("%s(): EEPROM initialization failed!\n", __FUNCTION__);
             return -1;
         }
     #else
-        #error("not supported MCU");
+        #error("MCU not supported");
     #endif
 
     /* It's not necessary here to check if any valid data are stored,
@@ -501,17 +499,7 @@ int storageGet(sto_item_id_t itemId, String& itemValue) {
         return -1;
     }
 
-    #if defined(ESP8266)
-        const uint8_t* storageDataPtr;
-        storageDataPtr = EEPROM.getConstDataPtr() + itemAddr;
-
-        if (isString(storageDataPtr, maxItemSize))  { // exist a null terminator?
-            itemValue = String((const char*)storageDataPtr); // convert to C++ string
-        } else {
-            Serial.printf("%s(): storage empty -> returning default\n", __FUNCTION__);
-            itemValue = String((PGM_P)&itemDefaults + itemAddr);  // set default string
-        }
-    #elif defined(ESP32)
+    #if defined(ESP32)
         // The ESP32 EEPROM class does not support getConstDataPtr()!
         uint8_t buf[maxItemSize];
         EEPROM.readBytes(itemAddr, buf, maxItemSize);

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -129,13 +129,13 @@ enum MACHINE {
 
 // Pin Layout
 #define ONE_WIRE_BUS 2             // Temp sensor pin
-#define PINPRESSURESENSOR 99       // Pressuresensor 0: A0 (ESP8266), >0 ONLY ESP32
+#define PINPRESSURESENSOR 99       // Pressuresensor
 #define PINVALVE 12                // Output pin for 3-way-valve
 #define PINPUMP 13                 // Output pin for pump
 #define PINHEATER 14               // Output pin for heater
 #define PINVOLTAGESENSOR  15       //Input pin for volatage sensor
 #define PINETRIGGER 16             // PIN for E-Trigger relay
-#define PINBREWSWITCH 0            // 0: A0 (ESP8266) ; >0 : DIGITAL PIN, ESP32 OR ESP8266: ONLY USE PIN15 AND PIN16!
+#define PINBREWSWITCH 0            // Digital Pin, ONLY USE PIN15 AND PIN16!
 #define PINSTEAMSWITCH 17          // STEAM active
 #define LEDPIN    18               // LED PIN ON near setpoint
 #define OLED_SCL 5                 // Output pin for dispaly clock pin
@@ -147,13 +147,7 @@ enum MACHINE {
 
 // Historic (no settings)
 #define PONE 1                     // 1 = P_ON_E (default), 0 = P_ON_M (special PID mode, other PID-parameter are needed)
-#define TEMPSENSOR 2               // 2 = TSIC306 1=DS18B20
-
-// Check BrewSwitch
-#if (defined(ESP8266) && ((PINBREWSWITCH != 15 && PINBREWSWITCH != 0 && PINBREWSWITCH != 16 )))
-  #error("WRONG Brewswitch PIN for ESP8266, Only PIN 15 and PIN 16");
-#endif
-
+#define TEMPSENSORTYPE 2           // 2 = TSIC306 1=DS18B20
 
 // defined compiler errors
 #if (PRESSURESENSOR == 1) && (PINPRESSURESENSOR == 0) && (PINBREWSWITCH == 0)


### PR DESCRIPTION
With the addition of the embedded webserver the ESP8266 ran into memory issues when using newer versions of the ESP-Arduino framework. Since the framework updates include security fixes it's not practical to keep it pinned to version 2.6.3 in the long run. Dropping ESP8266 support seems like the best option going forward.