### PR TITLE
Automatically add firmware revision, fix temp readout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       runs-on: self-hosted
       steps:
         - name: Checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
 

--- a/auto_firmware_version.py
+++ b/auto_firmware_version.py
@@ -1,0 +1,24 @@
+import pkg_resources
+
+Import("env")
+
+required_pkgs = {'dulwich'}
+installed_pkgs = {pkg.key for pkg in pkg_resources.working_set}
+missing_pkgs = required_pkgs - installed_pkgs
+
+if missing_pkgs:
+    env.Execute('$PYTHONEXE -m pip install dulwich --global-option="--pure"')
+
+from dulwich.repo import Repo
+
+def get_version_build_flag() -> str:
+    r = Repo('.')
+
+    build_version = r.head().decode("utf-8")[0:7]
+
+    build_flag = "-D AUTO_VERSION=\\\"" + build_version + "\\\""
+    print ("Firmware Revision: " + build_version)
+
+    return (build_flag)
+
+env.Append(BUILD_FLAGS=[get_version_build_flag()])

--- a/platformio_sample.ini
+++ b/platformio_sample.ini
@@ -26,6 +26,7 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 debug_tool = esp-prog
 debug_init_break = tbreak setup
+extra_scripts = pre:auto_firmware_version.py
 
 [env:esp32_ota]
 platform = espressif32
@@ -35,6 +36,7 @@ framework = arduino
 monitor_speed = 115200
 upload_protocol = espota
 upload_port = rancilio
-upload_flags =
-    --auth=otapass
+upload_flags = --auth=otapass
+extra_scripts = pre:auto_firmware_version.py
+
 

--- a/src/Displaytemplatestandard.h
+++ b/src/Displaytemplatestandard.h
@@ -62,43 +62,34 @@ void printScreen()
             u8g2.drawLine(13, 48, 13, 58 - (Input  / 2));
         }
 
-        //draw setPoint line
+        // draw setPoint line
         u8g2.drawLine(18, 58 - (setPoint / 2), 23, 58 - (setPoint / 2));
+        u8g2.setCursor(40, 48);
 
-        // PID Werte ueber heatbar , TOF wenn aktiv
-        if (percentage < 10.00 && TOF == 1) {
-            if (isrCounter < 500) {
-                u8g2.setCursor(40, 48);
-                u8g2.print(langstring_wasserleer);
-
-            }
-        } else {
-            u8g2.setCursor(40, 48);
-
-            u8g2.print(bPID.GetKp(), 0); // P
-            u8g2.print("|");
-            if (bPID.GetKi() != 0) {
-            u8g2.print(bPID.GetKp() / bPID.GetKi(), 0);;
-            } // I
-            else
-            {
-            u8g2.print("0");
-            }
-            u8g2.print("|");
-            u8g2.print(bPID.GetKd() / bPID.GetKp(), 0); // D
-            u8g2.setCursor(98, 48);
-            if (Output < 99) {
-            u8g2.print(Output / 10, 1);
-            } else {
-            u8g2.print(Output / 10, 0);
-            }
-            u8g2.print("%");
+        u8g2.print(bPID.GetKp(), 0); // P
+        u8g2.print("|");
+        if (bPID.GetKi() != 0) {
+        u8g2.print(bPID.GetKp() / bPID.GetKi(), 0);;
+        } // I
+        else
+        {
+        u8g2.print("0");
         }
-            // Brew
-            u8g2.setCursor(32, 34);
-            u8g2.print(langstring_brew);
-            u8g2.print(brewTime / 1000, 0);
-            u8g2.print("/");
+        u8g2.print("|");
+        u8g2.print(bPID.GetKd() / bPID.GetKp(), 0); // D
+        u8g2.setCursor(98, 48);
+        if (Output < 99) {
+        u8g2.print(Output / 10, 1);
+        } else {
+        u8g2.print(Output / 10, 0);
+        }
+        u8g2.print("%");
+
+        // Brew
+        u8g2.setCursor(32, 34);
+        u8g2.print(langstring_brew);
+        u8g2.print(brewTime / 1000, 0);
+        u8g2.print("/");
 
         if (ONLYPID == 1) {
             u8g2.print(brewtimersoftware, 0);   // deaktivieren wenn Preinfusion
@@ -141,12 +132,6 @@ void printScreen()
         } else {
             u8g2.setCursor(40, 2);
             u8g2.print(langstring_offlinemod);
-        }
-
-        if (TOF == 1) {
-            u8g2.setCursor(100, 2);
-            u8g2.printf("%.0f\n",percentage);   //display water level
-            u8g2.print((char)37);
         }
 
         u8g2.sendBuffer();

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -6,12 +6,6 @@
  */
 
 
-// Firmware version
-#define FW_VERSION    3
-#define FW_SUBVERSION 0
-#define FW_HOTFIX     1
-#define FW_BRANCH     "ALPHA"
-
 // Includes
 #include <ArduinoOTA.h>
 #include "rancilio-pid.h"
@@ -38,14 +32,6 @@ hw_timer_t *timer = NULL;
 #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
     #include <HX711_ADC.h>
 #endif
-
-// Version of userConfig need to match, checked by preprocessor
-#if (FW_VERSION != USR_FW_VERSION) || \
-    (FW_SUBVERSION != USR_FW_SUBVERSION) || \
-    (FW_HOTFIX != USR_FW_HOTFIX)
-    #error Version of userConfig file and rancilio-pid.cpp need to match!
-#endif
-
 
 MACHINE machine = (enum MACHINE)MACHINEID;
 
@@ -588,6 +574,8 @@ void refreshTemp() {
             * "temperature" will still hold old values
             */
             temperature = 0;
+
+            Temperature_C = TempSensor.getTemp();
 
             if (!checkSensor(Temperature_C) && firstreading == 0)
                 return; // if sensor data is not valid, abort function; Sensor must
@@ -1519,8 +1507,6 @@ void websiteSetup() {
 }
 
 void setup() {
-    const String sysVersion = "Version " + String(getFwVersion()) + " " + FW_BRANCH;
-
     Serial.begin(115200);
 
     initTimer1();
@@ -1569,7 +1555,7 @@ void setup() {
         u8g2.setI2CAddress(oled_i2c * 2);
         u8g2.begin();
         u8g2_prepare();
-        displayLogo(sysVersion, "");
+        displayLogo("Revision: ", AUTO_VERSION);
         delay(2000);
     #endif
 
@@ -1972,21 +1958,6 @@ void writeSysParamsToMQTT(void) {
         }
     }
 }
-
-/**
- * @brief Returns the firmware version as string (x.y.z).
- *
- * @return firmware version string
- */
-const char* getFwVersion(void)
-{
-    static const String sysVersion = String(FW_VERSION) + "." +
-                                     String(FW_SUBVERSION) + "." +
-                                     String(FW_HOTFIX);
-    return sysVersion.c_str();
-}
-
-
 
 /**
  * @brief Performs a factory reset.

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -1,7 +1,6 @@
 /**
  * @file    userConfig_sample.h
  * @brief   Values must be configured by the user
- * @version 3.0.1 Alpha
  *
  */
 
@@ -11,11 +10,6 @@
 #ifndef _userConfig_H
 #define _userConfig_H
 
-// firmware version (must match with definitions in the main source file)
-#define USR_FW_VERSION    3
-#define USR_FW_SUBVERSION 0
-#define USR_FW_HOTFIX     1
-#define USR_FW_BRANCH     "ALPHA"
 
 // List of supported machines
 enum MACHINE {


### PR DESCRIPTION
Uses the pre-build script hook of PlatformIO to write the short format commit hash to the firmware image instead of using a static version number.
This allows us to exactly identify which code is running on a particular system.