### PR TITLE
Move default parameters and gpio pin mapping out of userConfig

### DIFF
--- a/src/ISR.h
+++ b/src/ISR.h
@@ -15,9 +15,9 @@ void IRAM_ATTR onTimer(){
     timerAlarmWrite(timer, 10000, true);
 
     if (Output <= isrCounter) {
-        digitalWrite(PINHEATER, LOW);
+        digitalWrite(PIN_HEATER, LOW);
     } else {
-        digitalWrite(PINHEATER, HIGH);
+        digitalWrite(PIN_HEATER, HIGH);
     }
 
     isrCounter += 10; // += 10 because one tick = 10ms

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -6,6 +6,7 @@
 
 #include <Arduino.h>
 #include <EEPROM.h>
+#include "defaults.h"
 #include "userConfig.h"
 #include "Storage.h"
 

--- a/src/brewvoid.h
+++ b/src/brewvoid.h
@@ -150,7 +150,7 @@ void backflush() {
         Output = 0;
     }
 
-    digitalWrite(PINHEATER, LOW);  // Stop heating
+    digitalWrite(PIN_HEATER, LOW);  // Stop heating
 
     checkbrewswitch();
 
@@ -170,8 +170,8 @@ void backflush() {
 
         case 20:  // portafilter filling
             Serial.println("portafilter filling");
-            digitalWrite(PINVALVE, relayON);
-            digitalWrite(PINPUMP, relayON);
+            digitalWrite(PIN_VALVE, relayON);
+            digitalWrite(PIN_PUMP, relayON);
             backflushState = 21;
 
             break;
@@ -186,8 +186,8 @@ void backflush() {
 
         case 30:  // flushing
             Serial.println("flushing");
-            digitalWrite(PINVALVE, relayOFF);
-            digitalWrite(PINPUMP, relayOFF);
+            digitalWrite(PIN_VALVE, relayOFF);
+            digitalWrite(PIN_PUMP, relayOFF);
             flushCycles++;
             backflushState = 31;
 
@@ -206,8 +206,8 @@ void backflush() {
         case 43:  // waiting for brewswitch off position
             if (brewswitch == LOW) {
                 Serial.println("backflush finished");
-                digitalWrite(PINVALVE, relayOFF);
-                digitalWrite(PINPUMP, relayOFF);
+                digitalWrite(PIN_VALVE, relayOFF);
+                digitalWrite(PIN_PUMP, relayOFF);
                 flushCycles = 0;
                 backflushState = 10;
             }
@@ -265,8 +265,8 @@ void brew() {
 
             case 20:  // preinfusioon
                 Serial.println("Preinfusion");
-                digitalWrite(PINVALVE, relayON);
-                digitalWrite(PINPUMP, relayON);
+                digitalWrite(PIN_VALVE, relayON);
+                digitalWrite(PIN_PUMP, relayON);
                 brewcounter = 21;
 
                 break;
@@ -280,8 +280,8 @@ void brew() {
 
             case 30:  // preinfusion pause
                 Serial.println("preinfusion pause");
-                digitalWrite(PINVALVE, relayON);
-                digitalWrite(PINPUMP, relayOFF);
+                digitalWrite(PIN_VALVE, relayON);
+                digitalWrite(PIN_PUMP, relayOFF);
                 brewcounter = 31;
 
                 break;
@@ -295,8 +295,8 @@ void brew() {
 
             case 40:  // brew running
                 Serial.println("Brew started");
-                digitalWrite(PINVALVE, relayON);
-                digitalWrite(PINPUMP, relayON);
+                digitalWrite(PIN_VALVE, relayON);
+                digitalWrite(PIN_PUMP, relayON);
                 brewcounter = 41;
 
                 break;
@@ -312,8 +312,8 @@ void brew() {
 
             case 42:  // brew finished
                 Serial.println("Brew stopped");
-                digitalWrite(PINVALVE, relayOFF);
-                digitalWrite(PINPUMP, relayOFF);
+                digitalWrite(PIN_VALVE, relayOFF);
+                digitalWrite(PIN_PUMP, relayOFF);
                 brewcounter = 43;
                 brewTime = 0;
 
@@ -321,8 +321,8 @@ void brew() {
 
             case 43:  // waiting for brewswitch off position
                 if (brewswitch == LOW) {
-                    digitalWrite(PINVALVE, relayOFF);
-                    digitalWrite(PINPUMP, relayOFF);
+                    digitalWrite(PIN_VALVE, relayOFF);
+                    digitalWrite(PIN_PUMP, relayOFF);
 
                     // disarmed button
                     currentMillistemp = 0;

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -1,0 +1,26 @@
+/**
+ * @file defaults.h
+ *
+ * @brief Default values for user configurable system parameters
+ *
+ */
+
+#pragma once
+
+
+#define SETPOINT 95                // Brew temperature setpoint
+#define STEAMSETPOINT 120          // Steam temperature setpoint
+#define BREWDETECTIONLIMIT 150     // Brew detection limit, be careful: if too low there is a risk of wrong brew detection and rising temperature
+#define AGGKP 69                   // PID Kp (regular stage)
+#define AGGTN 399                  // PID Tn (regular stage)
+#define AGGTV 0                    // PID Tv (regular stage)
+#define STARTKP 50                 // PID Kp (coldstart stage)
+#define STARTTN 150                // PID Tn (coldstart stage)
+#define STEAMKP 150                // PID kp (steam stage)
+#define AGGBKP 50                  // PID Kp (brew detection stage)
+#define AGGBTN 0                   // PID Tn (brew detection stage)
+#define AGGBTV 20                  // PID Tv (brew detection stage)
+#define BREW_TIME 25               // Brew time in seconds
+#define BREW_SW_TIMER 45           // Brew software timer after detection in seconds
+#define PRE_INFUSION_TIME 2        // Pre-infusion time in seconds
+#define PRE_INFUSION_PAUSE_TIME 5  // Pre-infusion pause time in seconds

--- a/src/languages.h
+++ b/src/languages.h
@@ -49,7 +49,7 @@ static const char *langstring_bckfrunning[] = {"Backflush running:", "from"};
 
 static const char *langstring_offlinemod =    "Offline mode";
 
-static const char *langstring_wifirecon =     "Wifi reconnect:";
+// static const char *langstring_wifirecon =     "Wifi reconnect:";
 static const char *langstring_connectwifi1 =  "1: Connect Wifi to:";
 static const char *langstring_nowifi[] = {"No ", "WIFI"};
 

--- a/src/pinmapping.h
+++ b/src/pinmapping.h
@@ -1,0 +1,32 @@
+/**
+ * @file pinmapping.h
+ *
+ * @brief Default GPIO pin mapping
+ *
+ */
+
+#pragma once
+
+
+#define PIN_WATERSENSOR 36
+#define PIN_POWERSWITCH 39
+#define PIN_BREWSWITCH 34
+#define PIN_STEAMSWITCH 35
+#define PIN_HXDAT 32            // Brew scale data pin
+#define PIN_HXCLK 33            // Brew scale clock pin
+#define PIN_STEAMLED 25
+#define PIN_WATERLED 26
+#define PIN_POWERLED 27
+#define PIN_BREWLED 23
+#define PIN_STATUSLED 1
+#define PIN_ENCODERLEFT 4       // Rotary encoder left
+#define PIN_ENCODERRIGHT 5      // Rotary encoder right
+#define PIN_ENCODERBUTTON 3     // Rotary encoder pushbutton
+#define PIN_ZEROCROSSING 19     // Dimmer Circuit
+#define PIN_ONEWIRE 16
+#define PIN_I2CSCL 22
+#define PIN_I2CSDA 21
+#define PIN_PRESSURESENSOR 0
+#define PIN_VALVE 17
+#define PIN_PUMP 18
+#define PIN_HEATER 2

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -1,11 +1,8 @@
 /**
  * @file    userConfig.h
+ *
  * @brief   Values must be configured by the user
  *
- */
-
-/**
- * Define area, do not change anything here
  */
 
 #pragma once
@@ -18,10 +15,6 @@ enum MACHINE {
     Gaggia,           // MACHINEID 2
     QuickMill         // MACHINEID 3
 };
-
-/**
- * Preconfiguration
- */
 
 // Machine
 #define MACHINEID 0                // see above list of supported machines
@@ -39,37 +32,6 @@ enum MACHINE {
 
 // Connectivity
 #define CONNECTMODE 1              // 0 = offline 1 = WIFI-MODE 2 = AP-MODE (not working in the moment)
-#define MQTT 0                     // 1 = MQTT enabled, 0 = MQTT disabled
-#define INFLUXDB 0                // 1 = INFLUX enabled, 0 = INFLUX disabled
-
-// PID & Hardware
-#define ONLYPID 1                  // 1 = Only PID, 0 = PID and preinfusion
-#define ONLYPIDSCALE 0             // 0 = off , 1= OnlyPID with Scale
-#define BREWMODE 1                 // 1 = NORMAL preinfusion ; 2 = Scale with weight
-#define BREWDETECTION 1            // 0 = off, 1 = Software (Onlypid 1), 2 = Hardware (Onlypid 0), 3 = Sensor/Hardware for Only PID
-#define BREWSWITCHTYPE 1           // 1 = normal Switch, 2 = Trigger Switch
-#define COLDSTART_PID 1            // 1 = default coldstart values, 2 = custom values
-#define TRIGGERTYPE HIGH           // LOW = low trigger, HIGH = high trigger relay
-#define VOLTAGESENSORTYPE HIGH     // BREWDETECTION 3 configuration
-#define PINMODEVOLTAGESENSOR INPUT // Mode INPUT_PULLUP, INPUT or INPUT_PULLDOWN_16 (Only Pin 16)
-#define PRESSURESENSOR 0           // 1 = pressure sensor connected to A0; PINBREWSWITCH must be set to the connected input!
-
-//Weight SCALE
-#define SCALE_WEIGHTSETPOINT 30             // In grams
-#define SCALE_SAMPLES 2                     // Load cell sample rate
-#define SCALE_CALIBRATION_FACTOR 3195.83    // Raw data is divided by this value to convert to readable data
-
-
-/* Pressure sensor
- *
- * measure and verify "offset" value, should be 10% of ADC bit reading @supply volate (3.3V)
- * same goes for "fullScale", should be 90%
- */
-#define OFFSET      102            // 10% of ADC input @3.3V supply = 102
-#define FULLSCALE   922            // 90% of ADC input @3.3V supply = 922
-#define MAXPRESSURE 200
-
-/// Wifi
 #define HOSTNAME "silvia"
 #define PASS "CleverCoffee"        // default password for WiFiManager
 #define MAXWIFIRECONNECTS 5        // maximum number of reconnection attempts, use -1 to deactivate
@@ -80,14 +42,46 @@ enum MACHINE {
 #define OTAHOST "silvia"           // Name to be shown in ARUDINO IDE Port
 #define OTAPASS "CleverCoffeeOTA"  // Password for OTA updtates
 
+// PID & Hardware
+#define ONLYPID 1                  // 1 = Only PID, 0 = PID and preinfusion
+#define ONLYPIDSCALE 0             // 0 = off , 1= OnlyPID with Scale
+#define BREWMODE 1                 // 1 = NORMAL preinfusion ; 2 = Scale with weight
+#define BREWDETECTION 1            // 0 = off, 1 = Software (Onlypid 1), 2 = Hardware (Onlypid 0), 3 = Sensor/Hardware for Only PID
+#define BREWSWITCHTYPE 1           // 1 = normal Switch, 2 = Trigger Switch
+#define COLDSTART_PID 1            // 1 = default coldstart values, 2 = custom values
+#define TRIGGERTYPE HIGH           // LOW = low trigger, HIGH = high trigger relay
+#define VOLTAGESENSORTYPE HIGH     // Type of optocoupler for BREWDETECTION = 3
+
+// Brew scale
+#define SCALE_WEIGHTSETPOINT 30             // In grams
+#define SCALE_SAMPLES 2                     // Load cell sample rate
+#define SCALE_CALIBRATION_FACTOR 3195.83    // Raw data is divided by this value to convert to readable data
+
+// Backflush values
+#define FILLTIME 3000              // time in ms the pump is running
+#define FLUSHTIME 6000             // time in ms the 3-way valve is open -> backflush
+#define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
+
+/* Pressure sensor
+ *
+ * measure and verify "offset" value, should be 10% of ADC bit reading @supply volate (3.3V)
+ * same goes for "fullScale", should be 90%
+ */
+#define PRESSURESENSOR 0    // 1 = pressure sensor connected to A0; PINBREWSWITCH must be set to the connected input!
+#define OFFSET 102          // 10% of ADC input @3.3V supply = 102
+#define FULLSCALE 922       // 90% of ADC input @3.3V supply = 922
+#define MAXPRESSURE 200
+
 // MQTT
+#define MQTT 0
 #define MQTT_USERNAME "mymqttuser"
 #define MQTT_PASSWORD "mymqttpass"
-#define MQTT_TOPIC_PREFIX "custom/Küche."  // topic will be "<MQTT_TOPIC_PREFIX><HOSTNAME>/<READING>"
-#define MQTT_SERVER_IP "XXX.XXX.XXX.XXX"   // IP-Address of locally installed mqtt server
+#define MQTT_TOPIC_PREFIX "appliances/kitchen." // topic will be "<MQTT_TOPIC_PREFIX><HOSTNAME>/<READING>"
+#define MQTT_SERVER_IP "XXX.XXX.XXX.XXX"        // IP address of the local mqtt broker instance
 #define MQTT_SERVER_PORT 1883
 
 // INFLUXDB
+#define INFLUXDB 0
 #define INFLUXDB_URL ""            // InfluxDB server address
 #define INFLUXDB_AUTH_TYPE 1       // 1 = API Token , 2 = User/Pass
 #define INFLUXDB_API_TOKEN ""
@@ -96,47 +90,6 @@ enum MACHINE {
 #define INFLUXDB_PASSWORD ""
 #define INFLUXDB_DB_NAME "coffee"  // InfluxDB bucket name
 #define INFLUXDB_INTERVAL 5000     // Send interval in milliseconds
-
-// System Parameters (default values)
-#define SETPOINT 95                // brew temperatur setpoint
-#define STEAMSETPOINT 120          // steam temperatur setpoint
-#define BREWDETECTIONLIMIT 150     // brew detection limit, be carefull: if too low, then there is the risk of wrong brew detection and rising temperature
-#define AGGKP 69                   // PID Kp (regular phase)
-#define AGGTN 399                  // PID Tn (regular phase)
-#define AGGTV 0                    // PID Tv (regular phase)
-#define STARTKP 50                 // PID Kp (coldstart phase)
-#define STARTTN 150                // PID Tn (coldstart phase)
-#define STEAMKP 150                // PID kp (steam phase)
-#define AGGBKP 50                  // PID Kp (brew detection phase)
-#define AGGBTN 0                   // PID Tn (brew detection phase)
-#define AGGBTV 20                  // PID Tv (brew detection phase)
-#define BREW_TIME 25               // brew time in seconds
-#define BREW_SW_TIMER 45           // brew software timer after detection in seconds
-#define PRE_INFUSION_TIME 2        // pre-infusion time in seconds
-#define PRE_INFUSION_PAUSE_TIME 5  // pre-infusion pause time in seconds
-
-// Backflush values
-#define FILLTIME 3000              // time in ms the pump is running
-#define FLUSHTIME 6000             // time in ms the 3-way valve is open -> backflush
-#define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
-
-// Pin Layout
-#define ONE_WIRE_BUS 2             // Temp sensor pin
-#define PINPRESSURESENSOR 99       // Pressuresensor
-#define PINVALVE 12                // Output pin for 3-way-valve
-#define PINPUMP 13                 // Output pin for pump
-#define PINHEATER 14               // Output pin for heater
-#define PINVOLTAGESENSOR  15       //Input pin for volatage sensor
-#define PINETRIGGER 16             // PIN for E-Trigger relay
-#define PINBREWSWITCH 0            // Digital Pin, ONLY USE PIN15 AND PIN16!
-#define PINSTEAMSWITCH 17          // STEAM active
-#define LEDPIN    18               // LED PIN ON near setpoint
-#define OLED_SCL 5                 // Output pin for dispaly clock pin
-#define OLED_SDA 4                 // Output pin for dispaly data pin
-#define HXDATPIN 99                // weight scale PIN
-#define HXCLKPIN 99                // weight scale PIN
-#define SCREEN_WIDTH 128           // OLED display width, in pixels
-#define SCREEN_HEIGHT 64           // OLED display height, in pixels
 
 // Historic (no settings)
 #define PONE 1                     // 1 = P_ON_E (default), 0 = P_ON_M (special PID mode, other PID-parameter are needed)


### PR DESCRIPTION
- Default values for user configurable system parameters don't need to
  be in the userConfig
- With ESP32 there is enough I/O to specify a sensible default pin mapping
  without the need to remap pins depending on the feature set